### PR TITLE
Part II Feature/specialized exception

### DIFF
--- a/java-pinning-aar/src/main/java/eu/geekplace/javapinning/CertificateNotPinnedException.java
+++ b/java-pinning-aar/src/main/java/eu/geekplace/javapinning/CertificateNotPinnedException.java
@@ -1,0 +1,30 @@
+/**
+ *
+ * Copyright 2014 Florian Schmaus
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.geekplace.javapinning;
+
+import java.security.cert.CertificateException;
+
+/**
+ * This exception is thrown if the {@link PinningTrustManager} encounters a certificate that has not
+ * been pinned.
+ */
+public class CertificateNotPinnedException extends CertificateException {
+
+    public CertificateNotPinnedException(String message) {
+        super(message);
+    }
+}

--- a/java-pinning-aar/src/main/java/eu/geekplace/javapinning/PinningTrustManager.java
+++ b/java-pinning-aar/src/main/java/eu/geekplace/javapinning/PinningTrustManager.java
@@ -53,7 +53,7 @@ public class PinningTrustManager implements X509TrustManager {
 		// no use and most other software UIs show the "public key" without
 		// colons (and using lowercase letters).
 		final String pinHexString = HexUtilities.encodeToHex(leafCertificate.getEncoded());
-		throw new CertificateException("Certificate not pinned. Use 'CERTPLAIN:" + pinHexString
+		throw new CertificateNotPinnedException("Certificate not pinned. Use 'CERTPLAIN:" + pinHexString
 				+ "' to pin this certificate. But only pin the certificate if you are sure this is the correct certificate!");
 	}
 

--- a/java-pinning-jar/src/test/java/eu/geekplace/javapinning/PinningTrustManagerTest.java
+++ b/java-pinning-jar/src/test/java/eu/geekplace/javapinning/PinningTrustManagerTest.java
@@ -33,7 +33,7 @@ public class PinningTrustManagerTest {
 
 	private static final X509Certificate[] DUMMY_CHAIN = new X509Certificate[] {X509CertificateUtilities.decodeX509Certificate(HexUtilities.decodeFromHex(TestUtilities.PLAIN_CERTIFICATE_1))};
 
-	@Test(expected = CertificateException.class)
+	@Test(expected = CertificateNotPinnedException.class)
 	public void shouldThrowIfNotPinned() throws CertificateException {
 		X509TrustManager tm = JavaPinning.trustManagerForPin("CERTPLAIN:" + TestUtilities.PLAIN_CERTIFICATE_2);
 		tm.checkServerTrusted(DUMMY_CHAIN, "");


### PR DESCRIPTION
Part II in a series of pull-requests.

**Changes in this pull-request:**

- Added specialized exception `CertificateNotPinnedException` which is a sub-type of `CertificateException` this change allows users of the library to distinguish between not pinned exceptions and other certificate related exceptions.

**Files affected**
- `CertificateNotPinnedException.java` +
- `PinningTrustManager.java`
- `PinningTrustManagerTest.java`

**Release notes:** unless you want to write them yourself I will be doing a separate pull-request for the release notes.

Feel free to pull my fork and test this branch.