### PR TITLE
Part II, III and IV - Specialized exception, factory methods, release notes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,18 @@ See also the "Alternatives" section in this README.
 Changelog
 ---------
 
+### Upcoming Version
+
+- Added support for the Java 7 `X509ExtendedTrustManager` if your project uses Java 7 please use `Java7Pinning` instead of `JavaPinning`.
+- Two new factory methods `JavaPinning.trustManagerForPins(String...)` and `JavaPinning.forPins(String...)`.
+- Deprecated `JavaPinning.trustManagerforpins()` in favor of the correctly named `JavaPinning.trustManagerForpins()`.
+- Two new factory methods `CertPlainPin.fromCertificate` and `PlainPin.fromPublicKey` these methods can be used to directly create pins from X509 certificates or X509 public keys.
+- Two new getter methods `CertPlainPin.getX509Certificate()` and `PlainPin.getPublicKey()`.
+- Two new factory methods in `JavaPinning`
+- The `PinningTrustManager` now throws a specialized exception when a certificate is not pinned `CertificateNotPinnedException` which is a sub-type of `CertificateException`, this allows you to differentiate pinning exceptions from other certificate related exceptions.
+- New class `HexUtilities` which contains methods to decode from HEX to bytes and encode bytes to HEX
+- The `JavaPinningUtil` class has been deprecated in favor of `HexUtilities`, beaware of the fact that the methods in `HexUtilities` behave slightly better, but different).
+
 ### 1.0.1
 
 The Pin format requirements have been relaxed. The Pin string may now contain

--- a/java-pinning-aar/src/main/java/eu/geekplace/javapinning/CertificateNotPinnedException.java
+++ b/java-pinning-aar/src/main/java/eu/geekplace/javapinning/CertificateNotPinnedException.java
@@ -14,27 +14,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package eu.geekplace.javapinning.pin;
+package eu.geekplace.javapinning;
 
-import java.security.cert.CertificateEncodingException;
-import java.security.cert.X509Certificate;
+import java.security.cert.CertificateException;
 
-public abstract class CertPin extends Pin {
+/**
+ * This exception is thrown if the {@link PinningTrustManager} encounters a certificate that has not
+ * been pinned.
+ */
+public class CertificateNotPinnedException extends CertificateException {
 
-	protected CertPin(byte[] pinBytes) {
-		super(pinBytes);
-	}
-
-	protected CertPin(String pinHexString) {
-		super(pinHexString);
-	}
-
-	@Override
-	public boolean pinsCertificate(X509Certificate x509certificate) throws CertificateEncodingException {
-		byte[] pubkey = x509certificate.getEncoded();
-		return pinsCertificate(pubkey);
-	}
-
-	protected abstract boolean pinsCertificate(byte[] certificate);
-
+    public CertificateNotPinnedException(String message) {
+        super(message);
+    }
 }

--- a/java-pinning-aar/src/main/java/eu/geekplace/javapinning/JavaPinning.java
+++ b/java-pinning-aar/src/main/java/eu/geekplace/javapinning/JavaPinning.java
@@ -19,6 +19,7 @@ package eu.geekplace.javapinning;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -35,12 +36,29 @@ public class JavaPinning {
 
 	public static final JavaPinning INSTANCE = new JavaPinning();
 
+	public static X509TrustManager trustManagerForPins(String... pinStrings) {
+		return INSTANCE.tmForPins(pinStrings);
+	}
+
 	public static X509TrustManager trustManagerForPin(String pinString) {
 		return INSTANCE.tmForPin(pinString);
 	}
 
-	public static X509TrustManager trustManagerforPins(Collection<Pin> pins) {
+	public static X509TrustManager trustManagerForPins(Collection<Pin> pins){
 		return INSTANCE.tmForPins(pins);
+	}
+
+	/**
+	 * @deprecated Please use the correctly named: {@link #trustManagerForPins(Collection)}
+	 */
+	@Deprecated
+	public static X509TrustManager trustManagerforPins(Collection<Pin> pins) {
+		return trustManagerforPins(pins);
+	}
+
+	public static SSLContext forPins(String... pinStrings) throws KeyManagementException,
+			NoSuchAlgorithmException {
+		return INSTANCE.ctxForPins(pinStrings);
 	}
 
 	public static SSLContext forPin(String pinString) throws KeyManagementException,
@@ -57,8 +75,14 @@ public class JavaPinning {
 	}
 
 	protected final X509TrustManager tmForPin(String pinString) {
-		Pin pin = Pin.fromString(pinString);
-		List<Pin> pins = Arrays.asList(pin);
+		return tmForPins(pinString);
+	}
+
+	protected final X509TrustManager tmForPins(String... pinStrings) {
+		List<Pin> pins = new ArrayList<>(pinStrings.length);
+		for(String pin: pinStrings){
+			pins.add(Pin.fromString(pin));
+		}
 		return tmForPins(pins);
 	}
 
@@ -68,10 +92,15 @@ public class JavaPinning {
 		return trustManager;
 	}
 
+	protected final SSLContext ctxForPins(String... pinStrings) throws KeyManagementException,
+			NoSuchAlgorithmException {
+		TrustManager trustManager = tmForPins(pinStrings);
+		return fromTrustManager(trustManager);
+	}
+
 	protected final SSLContext ctxForPin(String pinString) throws KeyManagementException,
 			NoSuchAlgorithmException {
-		TrustManager trustManager = tmForPin(pinString);
-		return fromTrustManager(trustManager);
+		return ctxForPins(pinString);
 	}
 
 	protected final SSLContext ctxForPins(Collection<Pin> pins) throws KeyManagementException,

--- a/java-pinning-aar/src/main/java/eu/geekplace/javapinning/PinningTrustManager.java
+++ b/java-pinning-aar/src/main/java/eu/geekplace/javapinning/PinningTrustManager.java
@@ -53,7 +53,7 @@ public class PinningTrustManager implements X509TrustManager {
 		// no use and most other software UIs show the "public key" without
 		// colons (and using lowercase letters).
 		final String pinHexString = HexUtilities.encodeToHex(leafCertificate.getEncoded());
-		throw new CertificateException("Certificate not pinned. Use 'CERTPLAIN:" + pinHexString
+		throw new CertificateNotPinnedException("Certificate not pinned. Use 'CERTPLAIN:" + pinHexString
 				+ "' to pin this certificate. But only pin the certificate if you are sure this is the correct certificate!");
 	}
 

--- a/java-pinning-aar/src/main/java/eu/geekplace/javapinning/pin/CertPlainPin.java
+++ b/java-pinning-aar/src/main/java/eu/geekplace/javapinning/pin/CertPlainPin.java
@@ -16,6 +16,7 @@
  */
 package eu.geekplace.javapinning.pin;
 
+import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
 
@@ -25,12 +26,27 @@ public class CertPlainPin extends CertPin {
 
 	private final X509Certificate certificate;
 
+	protected CertPlainPin(X509Certificate certificate) throws CertificateEncodingException {
+		super(certificate.getEncoded());
+		this.certificate = certificate;
+	}
+
 	protected CertPlainPin(String pinHexString) {
 		super(pinHexString);
 		if (sha256md == null) {
 			throw new IllegalStateException("Can not create sha256 pins");
 		}
 		this.certificate = X509CertificateUtilities.decodeX509Certificate(pinBytes);
+	}
+
+	/**
+	 * Create a new "plain certificate" {@link Pin} from the given {@link X509Certificate}.
+	 * @param certificate the certificate to create a {@link Pin} for.
+	 * @return the {@link Pin} for the given certificate.
+	 * @throws CertificateEncodingException if the given certificate could not be encoded.
+	 */
+	public static CertPlainPin fromCertificate(X509Certificate certificate) throws CertificateEncodingException {
+		return new CertPlainPin(certificate);
 	}
 
 	@Override

--- a/java-pinning-aar/src/main/java/eu/geekplace/javapinning/pin/CertSha256Pin.java
+++ b/java-pinning-aar/src/main/java/eu/geekplace/javapinning/pin/CertSha256Pin.java
@@ -20,7 +20,6 @@ import java.util.Arrays;
 
 public class CertSha256Pin extends CertPin {
 
-
 	protected CertSha256Pin(String pinHexString) {
 		super(pinHexString);
 	}

--- a/java-pinning-aar/src/main/java/eu/geekplace/javapinning/pin/Pin.java
+++ b/java-pinning-aar/src/main/java/eu/geekplace/javapinning/pin/Pin.java
@@ -18,6 +18,7 @@ package eu.geekplace.javapinning.pin;
 
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
 import java.util.logging.Level;
@@ -43,6 +44,10 @@ public abstract class Pin {
 
 	protected final byte[] pinBytes;
 
+	protected Pin(byte[] pinBytes){
+		this.pinBytes = pinBytes;
+	}
+
 	protected Pin(String pinHexString) {
 		pinBytes = HexUtilities.decodeFromHex(pinHexString);
 	}
@@ -52,7 +57,7 @@ public abstract class Pin {
 	protected abstract boolean pinsCertificate(byte[] pubkey);
 
 	/**
-	 * Create a new Pin from the given String.
+	 * Create a new {@link Pin} from the given String.
 	 * <p>
 	 * The Pin String must be in the format <tt>[type]:[hex-string]</tt>, where
 	 * <tt>type</tt> denotes the type of the Pin and <tt>hex-string</tt> is the

--- a/java-pinning-aar/src/main/java/eu/geekplace/javapinning/pin/PlainPin.java
+++ b/java-pinning-aar/src/main/java/eu/geekplace/javapinning/pin/PlainPin.java
@@ -25,9 +25,23 @@ public class PlainPin extends PublicKeyPin {
 
 	private final PublicKey publicKey;
 
+	protected PlainPin(PublicKey publicKey) {
+		super(publicKey.getEncoded());
+		this.publicKey = publicKey;
+	}
+
 	protected PlainPin(String pinHexString) {
 		super(pinHexString);
 		this.publicKey = X509CertificateUtilities.decodeX509PublicKey(pinBytes);
+	}
+
+	/**
+	 * Create a new {@link Pin} from the given {@link PublicKey}.
+	 * @param publicKey the public-key to create a {@link Pin} for.
+	 * @return the {@link Pin} for the given certificate.
+	 */
+	public static PlainPin fromPublicKey(PublicKey publicKey) {
+		return new PlainPin(publicKey);
 	}
 
 	@Override

--- a/java-pinning-aar/src/main/java/eu/geekplace/javapinning/pin/PublicKeyPin.java
+++ b/java-pinning-aar/src/main/java/eu/geekplace/javapinning/pin/PublicKeyPin.java
@@ -20,10 +20,15 @@ import java.security.cert.X509Certificate;
 
 public abstract class PublicKeyPin extends Pin {
 
+	protected PublicKeyPin(byte[] encoded) {
+		super(encoded);
+	}
+
 	protected PublicKeyPin(String pinHexString) {
 		super(pinHexString);
 	}
 
+	@Override
 	public boolean pinsCertificate(X509Certificate x509certificate) {
 		byte[] pubkey = x509certificate.getPublicKey().getEncoded();
 		return pinsCertificate(pubkey);

--- a/java-pinning-jar/src/test/java/eu/geekplace/javapinning/PinningTrustManagerTest.java
+++ b/java-pinning-jar/src/test/java/eu/geekplace/javapinning/PinningTrustManagerTest.java
@@ -33,7 +33,7 @@ public class PinningTrustManagerTest {
 
 	private static final X509Certificate[] DUMMY_CHAIN = new X509Certificate[] {X509CertificateUtilities.decodeX509Certificate(HexUtilities.decodeFromHex(TestUtilities.PLAIN_CERTIFICATE_1))};
 
-	@Test(expected = CertificateException.class)
+	@Test(expected = CertificateNotPinnedException.class)
 	public void shouldThrowIfNotPinned() throws CertificateException {
 		X509TrustManager tm = JavaPinning.trustManagerForPin("CERTPLAIN:" + TestUtilities.PLAIN_CERTIFICATE_2);
 		tm.checkServerTrusted(DUMMY_CHAIN, "");

--- a/java-pinning-jar/src/test/java/eu/geekplace/javapinning/pin/PinTest.java
+++ b/java-pinning-jar/src/test/java/eu/geekplace/javapinning/pin/PinTest.java
@@ -21,8 +21,11 @@ import static org.junit.Assert.assertNotNull;
 
 import org.junit.Test;
 
+import java.security.cert.CertificateEncodingException;
+
 import eu.geekplace.javapinning.TestUtilities;
 import eu.geekplace.javapinning.util.HexUtilities;
+import eu.geekplace.javapinning.util.X509CertificateUtilities;
 
 public class PinTest {
 
@@ -78,5 +81,17 @@ public class PinTest {
 	public void fromString_plainPinHexString_returnsPlainPin(){
 		PlainPin plainPin = (PlainPin) Pin.fromString("PLAIN:" + TestUtilities.PLAIN_PUBLIC_KEY_1);
 		assertNotNull(plainPin.getPublicKey());
+	}
+
+	@Test
+	public void fromCertificate_notNull_returnsCertPLainPin() throws CertificateEncodingException {
+		CertPlainPin certPlainPin = CertPlainPin.fromCertificate(X509CertificateUtilities.decodeX509Certificate(TestUtilities.PLAIN_CERTIFICATE_1));
+		assertNotNull(certPlainPin);
+	}
+
+	@Test
+	public void fromPublicKey_notNull_returnsPLainPin() throws CertificateEncodingException {
+		PlainPin plainPin = PlainPin.fromPublicKey(X509CertificateUtilities.decodeX509PublicKey(TestUtilities.PLAIN_PUBLIC_KEY_1));
+		assertNotNull(plainPin);
 	}
 }

--- a/java-pinning-java7/src/main/java/eu/geekplace/javapinning/java7/Java7Pinning.java
+++ b/java-pinning-java7/src/main/java/eu/geekplace/javapinning/java7/Java7Pinning.java
@@ -32,12 +32,29 @@ public class Java7Pinning extends JavaPinning {
 
 	private static final Java7Pinning INSTANCE = new Java7Pinning();
 
+	public static X509TrustManager trustManagerForPins(String... pinStrings) {
+		return INSTANCE.tmForPins(pinStrings);
+	}
+
 	public static X509TrustManager trustManagerForPin(String pinString) {
 		return INSTANCE.tmForPin(pinString);
 	}
 
+	public static X509TrustManager trustManagerForPins(Collection<Pin> pins) {
+		return INSTANCE.tmForPins(pins);
+	}
+
+	/**
+	 * @deprecated Please use the correctly named: {@link #trustManagerForPins(Collection)}
+	 */
+	@Deprecated
 	public static X509TrustManager trustManagerforPins(Collection<Pin> pins) {
 		return INSTANCE.tmForPins(pins);
+	}
+
+	public static SSLContext forPins(String... pinString) throws KeyManagementException,
+			NoSuchAlgorithmException {
+		return INSTANCE.ctxForPins(pinString);
 	}
 
 	public static SSLContext forPin(String pinString) throws KeyManagementException,


### PR DESCRIPTION
**Changes in this pull-request:**
- Updated release notes
- Added two new factory methods: `CertPlainPin.fromCertificate` and `PlainPin.fromPublicKey`.
- Added two new factory methods to the `Java(7)Pinning` class `forPins(String...)` and `trustManagerForPins(String...)`.
- Deprecated (renamed) the `Java(7)Pinning.trustManagerforPins(Collection<Pin>)` method to `Java(7)Pinning.trustManagerForPins(Collection<Pin>)`
- Added specialized exception `CertificateNotPinnedException` which is a sub-type of `CertificateException` this change allows users of the library to distinguish between not pinned exceptions and other certificate related exceptions.
